### PR TITLE
Add RequestExecutionLevel

### DIFF
--- a/support/script.tpl
+++ b/support/script.tpl
@@ -17,6 +17,7 @@
 ;General
 
   OutFile "Setup.exe"
+  RequestExecutionLevel admin
   ShowInstDetails "nevershow"
   ShowUninstDetails "nevershow"
   ;SetCompressor "bzip2"


### PR DESCRIPTION
Since your installer writes files to `$PROGRAMFILES` and modifies `HKLM` is , it is recommended to add `RequestExecutionLevel admin`. While the installer will likely request these rights by default, it's safer to implicitly request them.
